### PR TITLE
Fixed a bug in the reconnect logic that was surfaced by a bug fix in 0.2.1

### DIFF
--- a/test/prioritized-pools.test.js
+++ b/test/prioritized-pools.test.js
@@ -45,6 +45,8 @@ describe('prioritized pools tests', () => {
         // force a prioritize cycle
         jest.runOnlyPendingTimers();
       })
+      // need to wait for the heal to finish during the prioritize cycle
+      .then(delay(1000, realSetTimeout))
       .then(() => {
         // confirm priority1 pool is now second and priority0 is now first
         expect(connection.pools[0].dsn.priority).toEqual(0);


### PR DESCRIPTION
In 0.2.1, a bug was fixed involving a failure to correctly detect failed pool-healing attempts. This ended up surfacing a bug in the reconnect logic. Once we started to correctly detect healing failures, a condition in the reconnect logic that prevented reconnects if all pools failed to heal started getting hit much more often. It turns out that preventing reconnects under this condition isn't desirable, as it sort of defeats the purpose of reconnects in the first place.  A change was made to detect when all pools failed to heal and skip straight to another heal attempt.

Also made some improvements to debug logging.